### PR TITLE
Add ssl options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then run the command below.
 docker run -v /path/to/.aws/creds/:/aws_creds 
 disneystreaming/pg2k4j 
 --awsconfiglocation=/aws_creds
---pgdatabase=<your_postgres_db> --pghost=<your_postgres_host> --pguser=<your_postgres_user> --pgpassword=<your_postgres_pw> --pgsslmode=require
+--pgdatabase=<your_postgres_db> --pghost=<your_postgres_host> --pguser=<your_postgres_user> --pgpassword=<your_postgres_pw>
 --streamname=<your_kinesis_streamname>
 ``` 
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then run the command below.
 docker run -v /path/to/.aws/creds/:/aws_creds 
 disneystreaming/pg2k4j 
 --awsconfiglocation=/aws_creds
---pgdatabase=<your_postgres_db> --pghost=<your_postgres_host> --pguser=<your_postgres_user> --pgpassword=<your_postgres_pw> 
+--pgdatabase=<your_postgres_db> --pghost=<your_postgres_host> --pguser=<your_postgres_user> --pgpassword=<your_postgres_pw> --pgsslmode=require
 --streamname=<your_kinesis_streamname>
 ``` 
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then run the command below.
 docker run -v /path/to/.aws/creds/:/aws_creds 
 disneystreaming/pg2k4j 
 --awsconfiglocation=/aws_creds
---pgdatabase=<your_postgres_db> --pghost=<your_postgres_host> --pguser=<your_postgres_user> --pgpassword=<your_postgres_pw>
+--pgdatabase=<your_postgres_db> --pghost=<your_postgres_host> --pguser=<your_postgres_user> --pgpassword=<your_postgres_pw> 
 --streamname=<your_kinesis_streamname>
 ``` 
 

--- a/src/main/java/com/disneystreaming/pg2k4j/CommandLineRunner.java
+++ b/src/main/java/com/disneystreaming/pg2k4j/CommandLineRunner.java
@@ -270,7 +270,9 @@ public class CommandLineRunner implements
     }
 
     @Override
-    public String getSslMode() { return sslMode; }
+    public String getSslMode() {
+        return sslMode;
+    }
 
     @Override
     public String getPathToRootCert() {

--- a/src/main/java/com/disneystreaming/pg2k4j/CommandLineRunner.java
+++ b/src/main/java/com/disneystreaming/pg2k4j/CommandLineRunner.java
@@ -144,7 +144,9 @@ public class CommandLineRunner implements
 
     @CommandLine.Option(
             names = {"--pgsslmode"},
-            description = "Refer to https://jdbc.postgresql.org/development/privateapi/org/postgresql/PGProperty.html#SSL_MODE "
+            description = "Refer to "
+                    + "https://jdbc.postgresql.org/development/privateapi/org/"
+                    + "postgresql/PGProperty.html#SSL_MODE "
                     + "for description and valid values.",
             required = false,
             defaultValue = PostgresConfiguration.DEFAULT_SSL_MODE
@@ -153,7 +155,9 @@ public class CommandLineRunner implements
 
     @CommandLine.Option(
             names = {"--pgpathtorootcert"},
-            description = "Refer to https://jdbc.postgresql.org/development/privateapi/org/postgresql/PGProperty.html#SSL_ROOT_CERT "
+            description = "Refer to "
+                    + "https://jdbc.postgresql.org/development/privateapi/org/"
+                    + "postgresql/PGProperty.html#SSL_ROOT_CERT "
                     + "for description. "
                     + "Example: /path/to/rds-combined-ca-bundle.pem",
             required = false
@@ -162,7 +166,9 @@ public class CommandLineRunner implements
 
     @CommandLine.Option(
             names = {"--pgpathtosslcert"},
-            description = "Refer to https://jdbc.postgresql.org/development/privateapi/org/postgresql/PGProperty.html#SSL_CERT "
+            description = "Refer to "
+                    + "https://jdbc.postgresql.org/development/privateapi/org/"
+                    + "postgresql/PGProperty.html#SSL_CERT "
                     + "for description. "
                     + "Example: /path/to/sslcert.pem",
             required = false
@@ -171,7 +177,9 @@ public class CommandLineRunner implements
 
     @CommandLine.Option(
             names = {"--pgpathtosslkey"},
-            description = "Refer to https://jdbc.postgresql.org/development/privateapi/org/postgresql/PGProperty.html#SSL_KEY "
+            description = "Refer to "
+                    + "https://jdbc.postgresql.org/development/privateapi/org/"
+                    + "postgresql/PGProperty.html#SSL_KEY "
                     + "for description. "
                     + "Example: /path/to/sslkey.pem",
             required = false
@@ -180,7 +188,9 @@ public class CommandLineRunner implements
 
     @CommandLine.Option(
             names = {"--pgsslpassword"},
-            description = "Refer to https://jdbc.postgresql.org/development/privateapi/org/postgresql/PGProperty.html#SSL_PASSWORD "
+            description = "Refer to "
+                    + "https://jdbc.postgresql.org/development/privateapi/org/"
+                    + "postgresql/PGProperty.html#SSL_PASSWORD "
                     + "for description. ",
             required = false
     )

--- a/src/main/java/com/disneystreaming/pg2k4j/CommandLineRunner.java
+++ b/src/main/java/com/disneystreaming/pg2k4j/CommandLineRunner.java
@@ -142,6 +142,50 @@ public class CommandLineRunner implements
     )
     private String slotName;
 
+    @CommandLine.Option(
+            names = {"--pgsslmode"},
+            description = "Refer to https://jdbc.postgresql.org/development/privateapi/org/postgresql/PGProperty.html#SSL_MODE "
+                    + "for description and valid values.",
+            required = false,
+            defaultValue = PostgresConfiguration.DEFAULT_SSL_MODE
+    )
+    private String sslMode;
+
+    @CommandLine.Option(
+            names = {"--pgpathtorootcert"},
+            description = "Refer to https://jdbc.postgresql.org/development/privateapi/org/postgresql/PGProperty.html#SSL_ROOT_CERT "
+                    + "for description. "
+                    + "Example: /path/to/rds-combined-ca-bundle.pem",
+            required = false
+    )
+    private String pathToRootCert;
+
+    @CommandLine.Option(
+            names = {"--pgpathtosslcert"},
+            description = "Refer to https://jdbc.postgresql.org/development/privateapi/org/postgresql/PGProperty.html#SSL_CERT "
+                    + "for description. "
+                    + "Example: /path/to/sslcert.pem",
+            required = false
+    )
+    private String pathToSslCert;
+
+    @CommandLine.Option(
+            names = {"--pgpathtosslkey"},
+            description = "Refer to https://jdbc.postgresql.org/development/privateapi/org/postgresql/PGProperty.html#SSL_KEY "
+                    + "for description. "
+                    + "Example: /path/to/sslkey.pem",
+            required = false
+    )
+    private String pathToSslKey;
+
+    @CommandLine.Option(
+            names = {"--pgsslpassword"},
+            description = "Refer to https://jdbc.postgresql.org/development/privateapi/org/postgresql/PGProperty.html#SSL_PASSWORD "
+                    + "for description. ",
+            required = false
+    )
+    private String sslPassword;
+
     @CommandLine.Option(names = {"-h", "--help"}, usageHelp = true,
             description = "Display this message")
     private boolean usageHelpRequested;
@@ -214,4 +258,28 @@ public class CommandLineRunner implements
     public String getPort() {
         return pgPort;
     }
+
+    @Override
+    public String getSslMode() { return sslMode; }
+
+    @Override
+    public String getPathToRootCert() {
+        return pathToRootCert;
+    }
+
+    @Override
+    public String getSslPassword() {
+        return sslPassword;
+    }
+
+    @Override
+    public String getPathToSslKey() {
+        return pathToSslKey;
+    }
+
+    @Override
+    public String getPathToSslCert() {
+        return pathToSslCert;
+    }
+
 }

--- a/src/main/java/com/disneystreaming/pg2k4j/PostgresConfiguration.java
+++ b/src/main/java/com/disneystreaming/pg2k4j/PostgresConfiguration.java
@@ -32,6 +32,7 @@ public interface PostgresConfiguration {
 
     String DEFAULT_PORT = "5432";
     String MIN_SERVER_VERSION = "10.3";
+    String DEFAULT_SSL_MODE = "disable";
 
     default String getPort() {
         return DEFAULT_PORT;
@@ -54,6 +55,26 @@ public interface PostgresConfiguration {
                 getPort(), getDatabase());
     }
 
+    default String getPathToRootCert() {
+        return null;
+    }
+
+    default String getSslPassword() {
+        return null;
+    }
+
+    default String getPathToSslKey() {
+        return null;
+    }
+
+    default String getPathToSslCert() {
+        return null;
+    }
+
+    default String getSslMode() {
+        return DEFAULT_SSL_MODE;
+    }
+
     default Properties getReplicationProperties() {
         Properties properties = getQueryConnectionProperties();
         PGProperty.PREFER_QUERY_MODE.set(properties, getQueryMode());
@@ -67,6 +88,11 @@ public interface PostgresConfiguration {
         PGProperty.PASSWORD.set(properties, getPassword());
         PGProperty.ASSUME_MIN_SERVER_VERSION.set(properties,
                 getMinServerVersion());
+        PGProperty.SSL_MODE.set(properties, getSslMode());
+        PGProperty.SSL_ROOT_CERT.set(properties, getPathToRootCert());
+        PGProperty.SSL_CERT.set(properties, getPathToSslCert());
+        PGProperty.SSL_PASSWORD.set(properties, getSslPassword());
+        PGProperty.SSL_KEY.set(properties, getPathToSslKey());
         return properties;
     }
 


### PR DESCRIPTION
Addresses https://github.com/disneystreaming/pg2k4j/issues/18

Add options for using an ssl connection to connect to postgres. Default behavior does not change. SSL_MODE by default is set to disable. To use an ssl connection specify a valid SSL_MODE as enumerated here https://jdbc.postgresql.org/development/privateapi/org/postgresql/PGProperty.html#SSL_MODE .